### PR TITLE
Fixing windows installer curl call (see #360)

### DIFF
--- a/k9s/install.ps1
+++ b/k9s/install.ps1
@@ -23,7 +23,7 @@ IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\webi\$Env:WEBI_PKG_FILE"))
 {
     # TODO: arch detection
     echo "Downloading k9s from $Env:WEBI_PKG_URL to $pkg_download"
-    & curl.exe -A -L "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$pkg_download.part"
     & move "$pkg_download.part" "$pkg_download"
 }
 


### PR DESCRIPTION
The environment variable $Env:WEBI_UA seems to be set to "Windows " followed by Arch (x64 etc.). Unfortunately, the parameters for the curl.exe call are "misplaced" and the user agent string is not passed to the -A parameter. This commit fixes this issue.